### PR TITLE
Updated commands.py

### DIFF
--- a/extensions/commands.py
+++ b/extensions/commands.py
@@ -91,7 +91,7 @@ class Commands(interactions.Extension):
             )
         ]
     )
-    async def update_c(self, ctx, location: str, force: bool = False):
+    async def update_spotdl(self, ctx, location: str, force: bool = False):
         match location:
             case "pip":
                 message = ("To update spotDL, run `pip install -U spotdl`")

--- a/extensions/commands.py
+++ b/extensions/commands.py
@@ -91,7 +91,7 @@ class Commands(interactions.Extension):
             )
         ]
     )
-    async def update(self, ctx, location: str, force: bool = False):
+    async def update_c(self, ctx, location: str, force: bool = False):
         match location:
             case "pip":
                 message = ("To update spotDL, run `pip install -U spotdl`")


### PR DESCRIPTION
Changed the name on the definition of the async function "update" to "update_c" (Stands for Update_command). This should fix the issue of update command not appearing on Discord Slash commands.

Feel free to make recomendations for its naming / change it to abide by the defined linting system.